### PR TITLE
Fix error in help message for argument --network

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import nn_utils
 print "==> parsing input arguments"
 parser = argparse.ArgumentParser()
 
-parser.add_argument('--network', type=str, default="dmn_batch", help='embeding size (50, 100, 200, 300 only)')
+parser.add_argument('--network', type=str, default="dmn_batch", help='network type: dmn_basic, dmn_smooth, or dmn_batch')
 parser.add_argument('--word_vector_size', type=int, default=50, help='embeding size (50, 100, 200, 300 only)')
 parser.add_argument('--dim', type=int, default=40, help='number of hidden units in input module GRU')
 parser.add_argument('--epochs', type=int, default=500, help='number of epochs')


### PR DESCRIPTION
Previously, the help message was the same as --word_vector_size.
Now it displays the proper options for choosing a network.
